### PR TITLE
Azure Cloudbase Terraform Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-# terraform-azure-cloudbase
+# Terraform Azure Cloudbase Module
+
+This Terraform module sets up Cloudbase security scanning for Azure environments.
+
+## Usage
+
+```hcl
+module "cloudbase" {
+  source = "Levetty/cloudbase/azure"
+
+  directory_id    = "your-azure-directory-id"
+  subscription_id = "your-azure-subscription-id"
+
+  federated_identity_credential_security_scan = {
+    audiences = ["api://AzureADTokenExchange"]
+    issuer    = "https://token.actions.githubusercontent.com"
+    subject   = "repo:your-org/your-repo:ref:refs/heads/main"
+  }
+}
+```
+
+## Required Variables
+
+- `directory_id`: The Azure Entra ID directory ID
+- `subscription_id`: The Azure subscription ID where security scanning will be performed
+- `federated_identity_credential_security_scan`: Federated Identity Credential for establishing a connection between your Azure environment and Cloudbase
+
+## Optional Variables
+
+- `enable_cnapp`: Enable CNAPP functions (default: true)
+- `cspm_permissions`: Specify the permissions for the CSPM role
+- `cwpp_permissions`: Specify the permissions for the CWPP role
+- `always_recreate_cloudbase_app`: Controls whether to always recreate the cloudbase_app (default: false)
+- `use_random_suffix`: Whether to append a random suffix to role definition names (default: true)
+
+## Outputs
+
+- `cloudbase_app_client_id`: The Client ID of the Cloudbase App
+- `subscription_id`: The subscription ID of your Azure Subscription
+- `directory_id`: The Directory ID of your Azure Directory

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,42 @@
+provider "azuread" {
+  tenant_id = var.directory_id
+}
+
+provider "azurerm" {
+  features {}
+  subscription_id = var.subscription_id
+}
+
+# Cloudbase App Module
+module "cloudbase-app" {
+  source = "./modules/cloudbase-app"
+
+  always_recreate_cloudbase_app = var.always_recreate_cloudbase_app
+  federated_identity_credential = var.federated_identity_credential
+}
+
+# Cloudbase Role Setup Module
+module "cloudbase-role-setup" {
+  source = "./modules/cloudbase-role-setup"
+
+  subscription_id      = var.subscription_id
+  service_principal_id = module.cloudbase-app.service_principal_id
+  enable_cnapp         = var.enable_cnapp
+  use_random_suffix    = var.use_random_suffix
+
+  cspm_role_def_name = var.cspm_permissions.custom.role_def_name
+  cspm_permissions = {
+    actions          = var.cspm_permissions.custom.permissions.actions
+    not_actions      = var.cspm_permissions.custom.permissions.not_actions
+    data_actions     = var.cspm_permissions.custom.permissions.data_actions
+    not_data_actions = var.cspm_permissions.custom.permissions.not_data_actions
+  }
+
+  cwpp_role_def_name = var.cwpp_permissions.custom.role_def_name
+  cwpp_permissions = {
+    actions          = var.cwpp_permissions.custom.permissions.actions
+    not_actions      = var.cwpp_permissions.custom.permissions.not_actions
+    data_actions     = var.cwpp_permissions.custom.permissions.data_actions
+    not_data_actions = var.cwpp_permissions.custom.permissions.not_data_actions
+  }
+}

--- a/modules/cloudbase-app/main.tf
+++ b/modules/cloudbase-app/main.tf
@@ -1,0 +1,84 @@
+# Data sources
+data "azuread_application_published_app_ids" "well_known" {}
+
+resource "azuread_service_principal" "msgraph" {
+  client_id    = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
+  use_existing = true
+}
+
+# Local variables
+locals {
+  now_utc = formatdate("YYYYMMDDhhmm", timestamp())
+  random  = var.always_recreate_cloudbase_app ? "-${local.now_utc}" : ""
+
+  # Microsoft Graph API permissions (excluding Organization.Read.All)
+  msgraph_resource_access = {
+    "User.Read.All" = {
+      id   = azuread_service_principal.msgraph.app_role_ids["User.Read.All"]
+      type = "Role"
+    }
+    "Policy.Read.All" = {
+      id   = azuread_service_principal.msgraph.app_role_ids["Policy.Read.All"]
+      type = "Role"
+    }
+    "AuditLog.Read.All" = {
+      id   = azuread_service_principal.msgraph.app_role_ids["AuditLog.Read.All"]
+      type = "Role"
+    }
+    "UserAuthenticationMethod.Read.All" = {
+      id   = azuread_service_principal.msgraph.app_role_ids["UserAuthenticationMethod.Read.All"]
+      type = "Role"
+    }
+  }
+}
+
+# Azure AD Application
+resource "azuread_application" "cloudbase_security_scan_app" {
+  display_name = "cloudbase-security-scan-app${local.random}"
+
+  required_resource_access {
+    resource_app_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
+
+    dynamic "resource_access" {
+      for_each = local.msgraph_resource_access
+      content {
+        id   = resource_access.value.id
+        type = resource_access.value.type
+      }
+    }
+  }
+}
+
+# Service Principal
+resource "azuread_service_principal" "cloudbase_security_scan_sp" {
+  description = "Cloudbase Security Scan App created by Terraform"
+  client_id   = azuread_application.cloudbase_security_scan_app.client_id
+}
+
+# App Role Assignments (Admin Consent)
+resource "azuread_app_role_assignment" "admin_consent" {
+  for_each            = local.msgraph_resource_access
+  app_role_id         = each.value.id
+  principal_object_id = azuread_service_principal.cloudbase_security_scan_sp.object_id
+  resource_object_id  = azuread_service_principal.msgraph.object_id
+}
+
+# Directory Role Assignment - Security Reader
+resource "azuread_directory_role" "security_reader" {
+  display_name = "Security Reader"
+}
+
+resource "azuread_directory_role_assignment" "security_reader" {
+  role_id             = azuread_directory_role.security_reader.template_id
+  principal_object_id = azuread_service_principal.cloudbase_security_scan_sp.object_id
+}
+
+# Federated Identity Credential for Security Scan
+resource "azuread_application_federated_identity_credential" "security_scan" {
+  application_id = azuread_application.cloudbase_security_scan_app.id
+  display_name   = "cloudbase-security-scan-credential"
+
+  issuer    = var.federated_identity_credential.issuer
+  audiences = var.federated_identity_credential.audiences
+  subject   = var.federated_identity_credential.subject
+}

--- a/modules/cloudbase-app/outputs.tf
+++ b/modules/cloudbase-app/outputs.tf
@@ -1,0 +1,14 @@
+output "application_client_id" {
+  description = "The client ID of the Azure AD application"
+  value       = azuread_application.cloudbase_security_scan_app.client_id
+}
+
+output "service_principal_id" {
+  description = "The object ID of the service principal"
+  value       = azuread_service_principal.cloudbase_security_scan_sp.object_id
+}
+
+output "service_principal_client_id" {
+  description = "The client ID of the service principal"
+  value       = azuread_service_principal.cloudbase_security_scan_sp.client_id
+}

--- a/modules/cloudbase-app/variables.tf
+++ b/modules/cloudbase-app/variables.tf
@@ -1,0 +1,14 @@
+variable "always_recreate_cloudbase_app" {
+  description = "Always recreate the Cloudbase app with a unique timestamp suffix"
+  type        = bool
+  default     = false
+}
+
+variable "federated_identity_credential" {
+  description = "Federated identity credential for security scan"
+  type = object({
+    issuer    = string
+    audiences = list(string)
+    subject   = string
+  })
+}

--- a/modules/cloudbase-app/versions.tf
+++ b/modules/cloudbase-app/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = "~> 1.11"
+  required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 3.3"
+    }
+  }
+}

--- a/modules/cloudbase-role-setup/main.tf
+++ b/modules/cloudbase-role-setup/main.tf
@@ -1,0 +1,62 @@
+locals {
+  now_utc = formatdate("YYYYMMDDhhmm", timestamp())
+  random  = var.use_random_suffix ? "-${local.now_utc}" : ""
+}
+
+# CSPM Role Definition
+resource "azurerm_role_definition" "cspm" {
+  name        = "${var.cspm_role_def_name}${local.random}"
+  scope       = "/subscriptions/${var.subscription_id}"
+  description = "Custom role for Cloudbase CSPM"
+
+  permissions {
+    actions          = var.cspm_permissions.actions
+    not_actions      = var.cspm_permissions.not_actions
+    data_actions     = var.cspm_permissions.data_actions
+    not_data_actions = var.cspm_permissions.not_data_actions
+  }
+
+  assignable_scopes = ["/subscriptions/${var.subscription_id}"]
+
+  lifecycle {
+    ignore_changes = [assignable_scopes, name, permissions]
+  }
+}
+
+# CWPP Role Definition (if enabled)
+resource "azurerm_role_definition" "cwpp" {
+  count       = var.enable_cnapp ? 1 : 0
+  name        = "${var.cwpp_role_def_name}${local.random}"
+  scope       = "/subscriptions/${var.subscription_id}"
+  description = "Custom role for Cloudbase CWPP"
+
+  permissions {
+    actions          = var.cwpp_permissions.actions
+    not_actions      = var.cwpp_permissions.not_actions
+    data_actions     = var.cwpp_permissions.data_actions
+    not_data_actions = var.cwpp_permissions.not_data_actions
+  }
+
+  assignable_scopes = ["/subscriptions/${var.subscription_id}"]
+
+  lifecycle {
+    ignore_changes = [assignable_scopes, name, permissions]
+  }
+}
+
+# CSPM Role Assignment
+resource "azurerm_role_assignment" "cspm" {
+  scope                            = "/subscriptions/${var.subscription_id}"
+  role_definition_id               = azurerm_role_definition.cspm.role_definition_resource_id
+  principal_id                     = var.service_principal_id
+  skip_service_principal_aad_check = true
+}
+
+# CWPP Role Assignment (if enabled)
+resource "azurerm_role_assignment" "cwpp" {
+  count                            = var.enable_cnapp ? 1 : 0
+  scope                            = "/subscriptions/${var.subscription_id}"
+  role_definition_id               = azurerm_role_definition.cwpp[0].role_definition_resource_id
+  principal_id                     = var.service_principal_id
+  skip_service_principal_aad_check = true
+}

--- a/modules/cloudbase-role-setup/outputs.tf
+++ b/modules/cloudbase-role-setup/outputs.tf
@@ -1,0 +1,19 @@
+output "cspm_role_definition_id" {
+  description = "The ID of the CSPM role definition"
+  value       = azurerm_role_definition.cspm.role_definition_resource_id
+}
+
+output "cwpp_role_definition_id" {
+  description = "The ID of the CWPP role definition"
+  value       = var.enable_cnapp ? azurerm_role_definition.cwpp[0].role_definition_resource_id : null
+}
+
+output "cspm_role_assignment_id" {
+  description = "The ID of the CSPM role assignment"
+  value       = azurerm_role_assignment.cspm.id
+}
+
+output "cwpp_role_assignment_id" {
+  description = "The ID of the CWPP role assignment"
+  value       = var.enable_cnapp ? azurerm_role_assignment.cwpp[0].id : null
+}

--- a/modules/cloudbase-role-setup/variables.tf
+++ b/modules/cloudbase-role-setup/variables.tf
@@ -1,0 +1,51 @@
+variable "subscription_id" {
+  description = "Azure Subscription ID"
+  type        = string
+}
+
+variable "service_principal_id" {
+  description = "Service Principal Object ID to assign roles to"
+  type        = string
+}
+
+variable "enable_cnapp" {
+  description = "Enable CNAPP (CWPP) role and permissions"
+  type        = bool
+  default     = false
+}
+
+variable "cspm_role_def_name" {
+  description = "Name for the CSPM role definition"
+  type        = string
+}
+
+variable "cspm_permissions" {
+  description = "Permissions for CSPM role"
+  type = object({
+    actions          = list(string)
+    not_actions      = list(string)
+    data_actions     = list(string)
+    not_data_actions = list(string)
+  })
+}
+
+variable "cwpp_role_def_name" {
+  description = "Name for the CWPP role definition"
+  type        = string
+}
+
+variable "cwpp_permissions" {
+  description = "Permissions for CWPP role"
+  type = object({
+    actions          = list(string)
+    not_actions      = list(string)
+    data_actions     = list(string)
+    not_data_actions = list(string)
+  })
+}
+
+variable "use_random_suffix" {
+  description = "Whether to append a random suffix to role definition names"
+  type        = bool
+  default     = true
+}

--- a/modules/cloudbase-role-setup/versions.tf
+++ b/modules/cloudbase-role-setup/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = "~> 1.11"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.26"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,22 @@
+output "cloudbase_app_client_id" {
+  description = "The Client ID of the Cloudbase App"
+  value       = module.cloudbase-app.application_client_id
+}
+
+output "subscription_id" {
+  description = "The subscription ID of your Azure Subscription"
+  value       = var.subscription_id
+}
+
+output "directory_id" {
+  description = "The Directory ID of your Azure Directory"
+  value       = var.directory_id
+}
+
+output "cspm_role_def_name" {
+  value = var.cspm_permissions.custom.role_def_name
+}
+
+output "cwpp_role_def_name" {
+  value = var.cwpp_permissions.custom.role_def_name
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,135 @@
+###############################################################################
+# Required
+###############################################################################
+variable "directory_id" {
+  description = "(required) The Azure Entra ID directory ID"
+  type        = string
+}
+
+variable "subscription_id" {
+  description = "(required) The Azure subscription ID where security scanning will be performed"
+  type        = string
+}
+
+variable "federated_identity_credential" {
+  type = object({
+    audiences = list(string)
+    issuer    = string
+    subject   = string
+  })
+  description = "(required) Federated Identity Credential for establishing a connection between your Azure environment and Cloudbase. Please provide the values supplied by Cloudbase for security scan."
+}
+
+###############################################################################
+# Optional 
+###############################################################################
+variable "enable_cnapp" {
+  default     = true
+  description = "(optional) Enable CNAPP functions. If it is true, both CSPM and CWPP role definitions will be created and assigned for comprehensive security scanning."
+  type        = bool
+}
+
+variable "cspm_permissions" {
+  description = <<EOT
+  (optional) Specify the permissions for the CSPM role.
+  EOT
+
+  type = object({
+    custom = object({
+      role_def_name = string
+      permissions = object({
+        actions          = list(string)
+        not_actions      = list(string)
+        data_actions     = list(string)
+        not_data_actions = list(string)
+      })
+    })
+    built_in = list(object({
+      name        = string
+      role_def_id = string
+    }))
+  })
+
+  default = {
+    custom = {
+      role_def_name = "CloudbaseCSPMRoleV20240906"
+      permissions = {
+        actions = [
+          "*/read",
+          "Microsoft.IoTSecurity/defenderSettings/downloadManagerActivation/action",
+          "Microsoft.IoTSecurity/defenderSettings/packageDownloads/action",
+          "Microsoft.Security/iotDefenderSettings/downloadManagerActivation/action",
+          "Microsoft.Security/iotDefenderSettings/packageDownloads/action",
+          "Microsoft.Security/iotSensors/downloadResetPassword/action",
+        ],
+        not_actions = [],
+        data_actions = [
+          "Microsoft.KeyVault/vaults/*/read",
+          "Microsoft.KeyVault/vaults/secrets/readMetadata/action",
+          "*/metadata/read"
+        ],
+        not_data_actions = []
+      }
+    }
+    built_in = []
+  }
+}
+
+variable "cwpp_permissions" {
+  description = <<EOT
+  (optional) Specify the permissions for the CWPP role.
+  EOT
+
+  type = object({
+    custom = object({
+      role_def_name = string
+      permissions = object({
+        actions          = list(string)
+        not_actions      = list(string)
+        data_actions     = list(string)
+        not_data_actions = list(string)
+      })
+    })
+    built_in = list(object({
+      name        = string
+      role_def_id = string
+    }))
+  })
+
+  default = {
+    custom = {
+      role_def_name = "CloudbaseCWPPRoleV20240906"
+      permissions = {
+        actions = [
+          "Microsoft.Resources/subscriptions/resourceGroups/write",
+          "Microsoft.Resources/subscriptions/resourceGroups/delete",
+          "Microsoft.Compute/snapshots/write",
+          "Microsoft.Compute/snapshots/delete",
+          "Microsoft.Compute/disks/beginGetAccess/action",
+          "Microsoft.Compute/disks/endGetAccess/action",
+          "Microsoft.Compute/snapshots/beginGetAccess/action",
+          "Microsoft.Compute/snapshots/endGetAccess/action",
+          "Microsoft.Storage/storageAccounts/listkeys/action",
+          "Microsoft.Web/sites/config/list/action",
+          "Microsoft.Web/sites/publishxml/Action"
+        ],
+        not_actions      = [],
+        data_actions     = [],
+        not_data_actions = []
+      }
+    }
+    built_in = []
+  }
+}
+
+variable "always_recreate_cloudbase_app" {
+  description = "(optional) Controls whether to always recreate the cloudbase_app. When set to true, the application will be recreated (with a new name) even if it already exists. Set to false if you are using remote Terraform state."
+  type        = bool
+  default     = false
+}
+
+variable "use_random_suffix" {
+  description = "(optional) Whether to append a random suffix to role definition names. This helps avoid conflicts when recreating roles."
+  type        = bool
+  default     = true
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.11"
+  
+  required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 3.3"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.26"
+    }
+  }
+}


### PR DESCRIPTION
## 概要
  Azure環境でCloudbaseセキュリティスキャンを実装するためのTerraformモジュールを追加しまし
  た。

  ## 変更内容
  ### 新機能
  - **Cloudbase App モジュール**: Azure ADアプリケーションとサービスプリンシパルを作成
    - Microsoft Graph APIの必要な権限を設定（User.Read.All、Policy.Read.All等）
    - Security Readerディレクトリロールを割り当て
    - GitHub Actionsとの連携用フェデレーション認証を設定

  - **Cloudbase Role Setup モジュール**: セキュリティスキャンのためのRBACを構成
    - CSPM（Cloud Security Posture Management）用カスタムロール定義
    - CWPP（Cloud Workload Protection Platform）用カスタムロール定義（オプション）
    - サブスクリプションレベルでのロール割り当て

  ### 主な特徴
  - **柔軟な権限管理**: CSPM/CWPPの権限をカスタマイズ可能
  - **再作成制御**: `always_recreate_cloudbase_app`フラグでアプリの再作成を制御
  - **ランダムサフィックス**: ロール名の競合を避けるためのタイムスタンプサフィックス対応
  - **モジュール構成**: 責任を明確に分離したサブモジュール設計

  ### 使用例
  ```hcl
  module "cloudbase" {
    source = "Levetty/cloudbase/azure"

    directory_id    = "your-azure-directory-id"
    subscription_id = "your-azure-subscription-id"

    federated_identity_credential = {
      audiences = ["api://AzureADTokenExchange"]
      issuer    = "https://token.actions.githubusercontent.com"
      subject   = "repo:your-org/your-repo:ref:refs/heads/main"
    }
  }
```

  テスト

  - モジュールのバリデーション（terraform validate）
  - プランの確認（terraform plan）
  - サンプル構成での動作確認

  関連情報

  - Terraform >= 1.11 が必要
  - Azure Provider: ~> 4.26
  - Azure AD Provider: ~> 3.3