### PR TITLE
feat: skip automatic resource provider registrations in azurerm provider 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,8 @@ provider "azuread" {
 
 provider "azurerm" {
   features {}
-  subscription_id = var.subscription_id
+  subscription_id                 = var.subscription_id
+  resource_provider_registrations = "none"
 }
 
 locals {


### PR DESCRIPTION
resource providerの自動登録をスキップするようにする
- Microsoft.Authorizationだけ欲しいが、これは`RegistrationFree`となっており登録する必要ない

https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/4.0-upgrade-guide#none-1