### PR TITLE
Update custom role versions and adjust CWPP permissions

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -52,7 +52,7 @@ variable "cspm_permissions" {
 
   default = {
     custom = {
-      role_def_name = "CloudbaseCSPMRoleV20240906_TERRAFORM"
+      role_def_name = "CloudbaseCSPMRoleV20260805_TERRAFORM"
       permissions = {
         actions = [
           "*/read",
@@ -100,19 +100,17 @@ variable "cwpp_permissions" {
 
   default = {
     custom = {
-      role_def_name = "CloudbaseCWPPRoleV20240906_TERRAFORM"
+      role_def_name = "CloudbaseCWPPRoleV20260805_TERRAFORM"
       permissions = {
         actions = [
           "Microsoft.Resources/subscriptions/resourceGroups/write",
           "Microsoft.Compute/snapshots/write",
           "Microsoft.Compute/snapshots/delete",
-          "Microsoft.Compute/disks/beginGetAccess/action",
-          "Microsoft.Compute/disks/endGetAccess/action",
           "Microsoft.Compute/snapshots/beginGetAccess/action",
           "Microsoft.Compute/snapshots/endGetAccess/action",
           "Microsoft.ContainerRegistry/registries/pull/read",
-          "Microsoft.Storage/storageAccounts/listkeys/action",
           "Microsoft.Web/sites/config/list/action",
+          "Microsoft.Web/sites/publish/Action",
           "Microsoft.Web/sites/publishxml/Action"
         ],
         not_actions      = [],


### PR DESCRIPTION
## Summary
- Bump CSPM and CWPP custom role definition names from `V20240906` to `V20260805`
- Remove no-longer-needed CWPP actions: `Microsoft.Compute/disks/beginGetAccess/action`, `Microsoft.Compute/disks/endGetAccess/action`, `Microsoft.Storage/storageAccounts/listkeys/action`
- Add `Microsoft.Web/sites/publish/Action` to CWPP permissions
